### PR TITLE
Fixed getByMultipleIndices when index returns no results

### DIFF
--- a/src/default_memory_storage.ts
+++ b/src/default_memory_storage.ts
@@ -167,10 +167,18 @@ export class MemoryStorage<T, PK = T[keyof T], K = T[keyof T]> implements IMemor
             return null;
         }
 
-        const sets = indices
-            .map((kf) => this.getByIndex(kf.indices, kf.keys))
-            .filter((set): set is Set<T> => set != null)
-            .sort((a, b) => a.size - b.size);
+        let sets: Set<T>[] = [];
+        for (const kf of indices) {
+            const set = this.getByIndex(kf.indices, kf.keys);
+            if (set === null) {
+                return null;
+            }
+
+            sets.push(set);
+        }
+
+        sets = sets.sort((a, b) => a.size - b.size);
+
         if (sets.length === 0) {
             return null;
         }

--- a/tests/default_memory_storage.test.ts
+++ b/tests/default_memory_storage.test.ts
@@ -525,4 +525,22 @@ describe('DefaultMemoryStorage', () => {
         // expect(store.size).toBe(2);
         expect(items).toEqual(null);
     });
+    it('Should return nothing if we didnt find anything with multiple indices', () => {
+        /* Given */
+        const getter = (i: Item) => i.primary;
+        const getter2 = (i: Item) => i.key2;
+        const getter3 = (i: Item) => i.key3;
+        const complexGetter1 = [getter2];
+        const complexGetter2 = [getter3];
+        const store = new MemoryStorage<Item>(getter, [complexGetter1, complexGetter2]);
+        store.addMultiple([item1, item2, item3, item4]);
+
+        /* When */
+        const items = store.getByMultipleIndices([
+            {indices: complexGetter1, keys: ['asdf']},
+            {indices: complexGetter2, keys: ['qqq']},
+        ]);
+
+        expect(items).toEqual(null);
+    });
 });


### PR DESCRIPTION
As far as I understand `getByMultipleIndices` should return an intersection of the sets returned from all indices (i.e. we only return the results that exist in ALL the sets from the indices). This means that when one of the indices returns null as a set, the entire result should be null. This wasn't handled correctly in the filtering logic, as all null sets were just ignored.